### PR TITLE
:recycle: rename param to not hide java keyword. Fixes #11

### DIFF
--- a/src/main/java/com/github/roroche/kstreamsmatchers/matchers/HasRecord.java
+++ b/src/main/java/com/github/roroche/kstreamsmatchers/matchers/HasRecord.java
@@ -175,9 +175,9 @@ public final class HasRecord<K, V> extends TypeSafeMatcher<KafkaRecord<K, V>> {
         }
 
         @Override
-        protected boolean matchesSafely(final TestRecord<K, V> record) {
+        protected boolean matchesSafely(final TestRecord<K, V> trecord) {
             return this.delegate.matches(
-                new KafkaRecord<>(record)
+                new KafkaRecord<>(trecord)
             );
         }
     }


### PR DESCRIPTION
Fixes #11 